### PR TITLE
Fix shebang and wsp script

### DIFF
--- a/tint2/less-is-more/wsp
+++ b/tint2/less-is-more/wsp
@@ -1,6 +1,6 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
-w=$(xprop -root -notype _NET_CURRENT_DESKTOP | grep -o [0-9])
+w=$(xprop -root -notype _NET_CURRENT_DESKTOP | grep -o '[0-9]')
 case "$w" in
     "0")  echo -e "\uf111 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7" ;;
     "1")  echo -e "\u00b7 \uf111 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7 \u00b7" ;;

--- a/warnai
+++ b/warnai
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 dir=$HOME/.themes/warna/
 conf=$HOME/.config/


### PR DESCRIPTION
- Use shebang "/usr/bin/env bash" to avoid different bash path in different distro
- Use quote to "grep -o" command in wsp to prevent no match found (In my laptop its error message is `zsh: no matches found: [0-9]`)